### PR TITLE
Update project repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node.js framework agnostic library that enables you to forward an http request to another HTTP server. 
 Supported protocols: HTTP, HTTPS, HTTP2
 
-> This library forked from `fastify-reply-from`: https://github.com/fastify/fastify-reply-from
+> This library was initially forked from `fastify-reply-from`: https://github.com/fastify/fastify-reply-from
 
 `fast-proxy` powers: https://www.npmjs.com/package/fast-gateway 🚀 
 ## Install
@@ -137,7 +137,7 @@ This will get passed to
 - https-agent: https://nodejs.org/api/https.html#https_class_https_agent
 
 ## Contributions 
-Special thanks to `fastify-reply-from` developers for creating a production ready library that we could initially fork.
+Special thanks to `fastify-reply-from` developers for creating a production ready library from where we could initially fork.
 
 ## License
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-proxy",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-proxy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-proxy",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "Forward your HTTP request to another server.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "fast-proxy",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Forward your HTTP request to another server.",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha test/*.test.js",
-    "bench": "( node benchmark/service.js & node benchmark/gateway.js & (sleep 5 && wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi) )"
+    "bench": "( node benchmark/service.js & node benchmark/fast-proxy-0http-gateway.js & (sleep 5 && wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi) )"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:jkyberneees/fast-proxy.git"
+    "url": "git@github.com:fastify/fast-proxy.git"
   },
   "keywords": [
     "http",
@@ -26,12 +26,12 @@
   "author": "Rolando Santamaria Maso",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jkyberneees/fast-proxy/issues"
+    "url": "https://github.com/fastify/fast-proxy/issues"
   },
   "engines": {
     "node": ">=8.0.0"
   },
-  "homepage": "https://github.com/jkyberneees/fast-proxy",
+  "homepage": "https://github.com/fastify/fast-proxy",
   "devDependencies": {
     "0http": "^2.2.2",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Updated:
- Project repository links now point to the fastify organisation instead of jkyberneees.
- Minor semantic documentation updates.

Fixes:
- Gateway path in `npm run bench` script was fixed.