### PR TITLE
Port content-type fixes

### DIFF
--- a/tests/full-post-extended-content-type.js
+++ b/tests/full-post-extended-content-type.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const fastProxy = require('..')
+const http = require('http')
+const get = require('simple-get')
+const t = require('tap')
+
+t.plan(10)
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'POST')
+  t.equal(req.headers['content-type'].startsWith('application/json'), true)
+  var data = ''
+  req.setEncoding('utf8')
+  req.on('data', (d) => {
+    data += d
+  })
+  req.on('end', () => {
+    t.deepEqual(JSON.parse(data), { hello: 'world' })
+    res.statusCode = 200
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ something: 'else' }))
+  })
+})
+t.tearDown(target.close.bind(target))
+
+const source = http.createServer((req, res) => {
+  const { proxy } = fastProxy({
+    base: `http://localhost:${target.address().port}`
+  })
+  t.equal(req.method, 'POST')
+  proxy(req, res, req.url)
+})
+t.tearDown(source.close.bind(source))
+
+const instance = source.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(0, (err) => {
+    t.error(err)
+
+    get.concat({
+      url: `http://localhost:${instance.address().port}`,
+      method: 'POST',
+      body: JSON.stringify({
+        hello: 'world'
+      }),
+      headers: {
+        'content-type': 'application/json;charset=utf-8'
+      }
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'application/json')
+      t.deepEqual(JSON.parse(data.toString()), { something: 'else' })
+    })
+  })
+})

--- a/tests/post-plain-text.js
+++ b/tests/post-plain-text.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const fastProxy = require('..')
+const http = require('http')
+const get = require('simple-get').concat
+const t = require('tap')
+
+t.plan(10)
+
+const target = http.createServer((req, res) => {
+  t.pass('request proxied')
+  t.equal(req.method, 'POST')
+  t.equal(req.headers['content-type'], 'text/plain')
+  var data = ''
+  req.setEncoding('utf8')
+  req.on('data', (d) => {
+    data += d
+  })
+  req.on('end', () => {
+    const str = data.toString()
+    t.deepEqual(str, 'this is plain text')
+    res.statusCode = 200
+    res.setHeader('content-type', 'text/plain')
+    res.end(str)
+  })
+})
+t.tearDown(target.close.bind(target))
+
+const source = http.createServer((req, res) => {
+  const { proxy } = fastProxy({
+    base: `http://localhost:${target.address().port}`
+  })
+  t.equal(req.method, 'POST')
+  proxy(req, res, req.url)
+})
+t.tearDown(source.close.bind(source))
+
+const instance = source.listen(0, (err) => {
+  t.error(err)
+
+  target.listen(0, (err) => {
+    t.error(err)
+
+    get({
+      url: `http://localhost:${instance.address().port}`,
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: 'this is plain text'
+    }, (err, res, data) => {
+      t.error(err)
+      t.equal(res.headers['content-type'], 'text/plain')
+      t.deepEqual(data.toString(), 'this is plain text')
+    })
+  })
+})


### PR DESCRIPTION
This ports the following fixes: https://github.com/fastify/fastify-reply-from/commit/c47969d2e0d93e6fb919c693ad9d5225639bc5ad and https://github.com/fastify/fastify-reply-from/commit/99d3d55de5ecfe7980b661d9fcecd46ea0157930

Do note: I am still in alignment process so still two test frameworks here. Do note that both the default tests in this repo and the ported test for the fix from `fastify-reply-from` is passing.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
