### PR TITLE
consider default ports while generating the Host header

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,10 @@ module.exports = (opts) => {
       const sourceHttp2 = req.httpVersionMajor === 2
       const headers = { ...sourceHttp2 ? filterPseudoHeaders(req.headers) : req.headers }
       headers['x-forwarded-host'] = req.headers.host
-      headers.host = `${url.hostname}:${url.port}`
+      headers.host = url.hostname
+      if (url.port) {
+        headers.host += `:${url.port}`
+      }
 
       const qs = getQueryString(url.search, req.url, opts)
 

--- a/test/6.nocache.test.js
+++ b/test/6.nocache.test.js
@@ -26,7 +26,6 @@ describe('no URLs cache', () => {
 
     gateway.all('/service/*', function (req, res) {
       proxy(req, res, req.url, {
-        base: req.headers.base,
         onResponse (req, res, stream) {
           pump(stream, res)
         }

--- a/test/7.hooks.test.js
+++ b/test/7.hooks.test.js
@@ -24,7 +24,6 @@ describe('hooks', () => {
 
     gateway.all('/service/*', function (req, res) {
       proxy(req, res, req.url, {
-        base: req.headers.base,
         rewriteHeaders: (headers) => {
           headers['x-reponse-hook'] = '1'
 

--- a/test/8.proxs-headers.test.js
+++ b/test/8.proxs-headers.test.js
@@ -1,0 +1,82 @@
+/* global describe, it */
+'use strict'
+
+const request = require('supertest')
+const expect = require('chai').expect
+const nock = require('nock')
+let gateway, close, proxy, gHttpServer
+
+nock('http://service1.com')
+  .get('/service1/health')
+  .reply(200)
+nock('https://service2.com:4443')
+  .get('/service2/health')
+  .reply(200)
+
+describe('proxy headers', () => {
+  let host, xForwardedHost
+
+  it('init', async () => {
+    const fastProxy = require('../index')({
+    })
+    close = fastProxy.close
+    proxy = fastProxy.proxy
+
+    expect(proxy instanceof Function).to.equal(true)
+    expect(close instanceof Function).to.equal(true)
+  })
+
+  it('init & start gateway', async () => {
+    // init gateway
+    gateway = require('restana')()
+    gateway.get('/service1/health', function (req, res) {
+      proxy(req, res, req.url, {
+        base: 'http://service1.com',
+        rewriteRequestHeaders: (req, headers) => {
+          host = headers.host
+          xForwardedHost = headers['x-forwarded-host']
+
+          return headers
+        }
+      })
+    })
+    gateway.get('/service2/health', function (req, res) {
+      proxy(req, res, req.url, {
+        base: 'https://service2.com:4443',
+        rewriteRequestHeaders: (req, headers) => {
+          host = headers.host
+          xForwardedHost = headers['x-forwarded-host']
+
+          return headers
+        }
+      })
+    })
+
+    gHttpServer = await gateway.start(8080)
+  })
+
+  it('should properly set proxy headers on default port', async () => {
+    await request(gHttpServer)
+      .get('/service1/health')
+      .expect(200)
+      .then((response) => {
+        expect(host).to.equal('service1.com')
+        expect(xForwardedHost).to.equal('127.0.0.1:8080')
+      })
+  })
+
+  it('should properly set proxy headers on custom port', async () => {
+    await request(gHttpServer)
+      .get('/service2/health')
+      .expect(200)
+      .then((response) => {
+        expect(host).to.equal('service2.com:4443')
+        expect(xForwardedHost).to.equal('127.0.0.1:8080')
+      })
+  })
+
+  it('close all', async () => {
+    close()
+    await gateway.close()
+  })
+})


### PR DESCRIPTION
Changes:
- Fixes an issue related to the `Host` header generation when default ports like 80 or 443

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
