### PR TITLE
Add follow redirects support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ This flag could controls the settings of the undici client, like so:
 The number of parsed URLs that will be cached. Default: 100.
 > Use value = `0` to disable the caching mechanism
 
+#### followRedirects
+Specify whether you want to follow redirects. Default: false.
+
 #### keepAliveMsecs
 Defaults to 1 minute, passed down to [`http.Agent`][http-agent] and
 [`https.Agent`][https-agent] instances.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,19 @@ This flag could controls the settings of the undici client, like so:
 The number of parsed URLs that will be cached. Default: 100.
 > Use value = `0` to disable the caching mechanism
 
-#### followRedirects
-Specify whether you want to follow redirects. Default: false.
+#### requests.http and requests.https
+Override the internal `http` and `https` clients. Defaults: [`http`](https://nodejs.org/api/http.html#http_http) and [`https`](https://nodejs.org/api/https.html#https_https).
+
+This could be used to add support for following redirects, like so:
+
+```js
+...
+  requests: {
+    http: require('follow-redirects/http'),
+    https: require('follow-redirects/https')
+  }
+...
+```
 
 #### keepAliveMsecs
 Defaults to 1 minute, passed down to [`http.Agent`][http-agent] and

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,24 +1,20 @@
 'use strict'
 
 const semver = require('semver')
+const http = require('http')
+const https = require('https')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const { stripHttp1ConnectionHeaders } = require('./utils')
 const undici = require('undici')
 
-const nativeRequests = {
-  'http:': require('http'),
-  'https:': require('https')
-}
-const followRedirectRequests = {
-  'http:': require('follow-redirects/http'),
-  'https:': require('follow-redirects/https')
-}
-
 function buildRequest (opts) {
   const isHttp2 = !!opts.http2
   const isUndici = !!opts.undici
-  const requests = opts.followRedirects ? followRedirectRequests : nativeRequests
+  const requests = {
+    'http:': opts.requests && opts.requests.http ? opts.requests.http : http,
+    'https:': opts.requests && opts.requests.https ? opts.requests.https : https,
+  }
   const baseUrl = opts.base
   const rejectUnauthorized = opts.rejectUnauthorized
   let h2client
@@ -33,8 +29,8 @@ function buildRequest (opts) {
     if (!opts.base) throw new Error('Option base is required when http2 is true')
   } else {
     agents = {
-      'http:': new requests['http:'].Agent(agentOption(opts)),
-      'https:': new requests['https:'].Agent(agentOption(opts))
+      'http:': new http.Agent(agentOption(opts)),
+      'https:': new https.Agent(agentOption(opts))
     }
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,20 +1,24 @@
 'use strict'
 
 const semver = require('semver')
-const http = require('http')
-const https = require('https')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const { stripHttp1ConnectionHeaders } = require('./utils')
 const undici = require('undici')
 
+const nativeRequests = {
+  'http:': require('http'),
+  'https:': require('https')
+}
+const followRedirectRequests = {
+  'http:': require('follow-redirects/http'),
+  'https:': require('follow-redirects/https')
+}
+
 function buildRequest (opts) {
   const isHttp2 = !!opts.http2
   const isUndici = !!opts.undici
-  const requests = {
-    'http:': http,
-    'https:': https
-  }
+  const requests = opts.followRedirects ? followRedirectRequests : nativeRequests
   const baseUrl = opts.base
   const rejectUnauthorized = opts.rejectUnauthorized
   let h2client
@@ -29,8 +33,8 @@ function buildRequest (opts) {
     if (!opts.base) throw new Error('Option base is required when http2 is true')
   } else {
     agents = {
-      'http:': new http.Agent(agentOption(opts)),
-      'https:': new https.Agent(agentOption(opts))
+      'http:': new requests['http:'].Agent(agentOption(opts)),
+      'https:': new requests['https:'].Agent(agentOption(opts))
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chai": "^4.2.0",
     "fastify": "^2.13.0",
     "fastify-reply-from": "^2.0.1",
+    "follow-redirects": "^1.11.0",
     "h2url": "^0.2.0",
     "http-proxy": "^1.18.0",
     "mocha": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "end-of-stream": "^1.4.4",
+    "follow-redirects": "^1.11.0",
     "pump": "^3.0.0",
     "semver": "^7.2.1",
     "tiny-lru": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "end-of-stream": "^1.4.4",
-    "follow-redirects": "^1.11.0",
     "pump": "^3.0.0",
     "semver": "^7.2.1",
     "tiny-lru": "^7.0.2",

--- a/test/9.custom-request-clients.test.js
+++ b/test/9.custom-request-clients.test.js
@@ -1,0 +1,119 @@
+/* global describe, it */
+'use strict'
+
+const request = require('supertest')
+const expect = require('chai').expect
+
+let service
+
+describe('fast-proxy custom request clients', () => {
+  it('init & start remote service', async () => {
+    // init remote service
+    service = require('restana')()
+
+    service.get('/service/redirect', (req, res) => {
+      res.setHeader('location', '/service/redirected')
+      res.send(301)
+    })
+    service.get('/service/redirected', (req, res) => {
+      res.setHeader('url', req.url)
+      res.send()
+    })
+
+    await service.start(3000)
+  })
+
+  describe('with default request clients', () => {
+    let gateway, close, proxy, gHttpServer
+
+    it('init proxy', async () => {
+      const fastProxy = require('../index')({
+        base: 'http://127.0.0.1:3000'
+      })
+      close = fastProxy.close
+      proxy = fastProxy.proxy
+
+      expect(proxy instanceof Function).to.equal(true)
+      expect(close instanceof Function).to.equal(true)
+    })
+
+    it('init & start gateway', async () => {
+      // init gateway
+      gateway = require('restana')()
+
+      gateway.all('/service/*', function (req, res) {
+        proxy(req, res, req.url, {
+          base: req.headers.base,
+          queryString: { age: 33 }
+        })
+      })
+
+      gHttpServer = await gateway.start(8080)
+    })
+
+    it('should 301 on redirected url', async () => {
+      await request(gHttpServer)
+        .get('/service/redirect')
+        .expect(301)
+        .then((response) => {
+          expect(response.headers.url).not.to.equal('/service/redirected')
+        })
+    })
+
+    after(async () => {
+      close()
+      await gateway.close()
+    })
+  })
+
+  describe('with custom request clients that follow redirects', () => {
+    let gateway, close, proxy, gHttpServer
+
+    it('init proxy', async () => {
+      const fastProxy = require('../index')({
+        base: 'http://127.0.0.1:3000',
+        requests: {
+          http: require('follow-redirects/http'),
+          https: require('follow-redirects/https')
+        },
+      })
+      close = fastProxy.close
+      proxy = fastProxy.proxy
+
+      expect(proxy instanceof Function).to.equal(true)
+      expect(close instanceof Function).to.equal(true)
+    })
+
+    it('init & start gateway', async () => {
+      // init gateway
+      gateway = require('restana')()
+
+      gateway.all('/service/*', function (req, res) {
+        proxy(req, res, req.url, {
+          base: req.headers.base,
+          queryString: { age: 33 }
+        })
+      })
+
+      gHttpServer = await gateway.start(8081)
+    })
+
+    it('should 200 on redirected url', async () => {
+      await request(gHttpServer)
+        .get('/service/redirect')
+        .expect(200)
+        .then((response) => {
+          expect(response.headers.url).to.equal('/service/redirected')
+        })
+    })
+
+    after(async () => {
+      close()
+      await gateway.close()
+    })
+  })
+
+  after(async () => {
+    await service.close()
+  })
+})


### PR DESCRIPTION
~~This PR adds an opt-in feature to follow redirects. I've [implemented it by using the package `follow-redirects` similarly to how this was done in `http-proxy`](https://github.com/http-party/node-http-proxy/blob/4a657a71267ae093e43473a155a3bb9dfc9784f8/lib/http-proxy/passes/web-incoming.js#L5).~~

~~I am not sure whether you'd want to do this another way, or what kind of benchmark/test this needs if any (the functionality technically belongs to an external package). I found another slightly crufty approach [here](https://github.com/fastify/fastify-http-proxy/issues/46#issuecomment-559944403), but I felt that [`follow-redirects`](https://github.com/follow-redirects/follow-redirects) would be a more dependable approach since it has tests (and a surprising amount of code), etc.~~

I guess another possibility would be to let people pass in `http` and `https` themselves, but other than `follow-redirects` I don't know any other wrappers around these libraries, so I think it's best to just use them internally.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
