### PR TITLE
Preset origin response code

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,10 +109,12 @@ module.exports = (opts) => {
           copyHeaders(rewriteHeaders(headers), res)
         }
 
+        // set origin response code
+        res.statusCode = statusCode
+
         if (onResponse) {
           onResponse(req, res, stream)
         } else {
-          res.statusCode = statusCode
           pump(stream, res)
         }
       })

--- a/test/4.opts.test.js
+++ b/test/4.opts.test.js
@@ -91,7 +91,7 @@ describe('fast-proxy smoke', () => {
       })
   })
 
-  it('should support http status in on response', async () => {
+  it('should retrieve http status from origin', async () => {
     await request(gHttpServer)
       .get('/service/302')
       .expect(302)

--- a/test/4.opts.test.js
+++ b/test/4.opts.test.js
@@ -50,10 +50,15 @@ describe('fast-proxy smoke', () => {
     service = require('restana')()
     service.use(bodyParser.json())
 
-    service.get('/service/headers', (req, res) => {
-      res.setHeader('url', req.url)
-      res.send()
-    })
+    service
+      .get('/service/headers', (req, res) => {
+        res.setHeader('url', req.url)
+        res.send()
+      })
+      .get('/service/302', (req, res) => {
+        res.statusCode = 302
+        res.end()
+      })
 
     await service.start(3000)
   })
@@ -84,6 +89,12 @@ describe('fast-proxy smoke', () => {
       .then((response) => {
         expect(response.headers.url).to.equal('http://dev.com')
       })
+  })
+
+  it('should support http status in on response', async () => {
+    await request(gHttpServer)
+      .get('/service/302')
+      .expect(302)
   })
 
   it('close all', async () => {


### PR DESCRIPTION
In this PR we preset the origin response code before calling any custom `onResponse` hook if provided.  
This simplifies custom `onResponse` implementations, as devs can expect the origin response code being set.  

Fixes: https://github.com/fastify/fast-proxy/issues/30#issuecomment-653527047

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
