### PR TITLE
Add support to application/x-www-form-urlencoded content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ module.exports = (opts) => {
           } else if (typeof req.body === 'string') {
             body = req.body
             populateHeaders(headers, body, 'text/plain')
+          } else if (headers['content-type'] === 'application/x-www-form-urlencoded') {
+            body = querystring.stringify(req.body)
+            populateHeaders(headers, body, 'application/x-www-form-urlencoded')
           } else {
             body = JSON.stringify(req.body)
             populateHeaders(headers, body, 'application/json')

--- a/test/1.smoke.test.js
+++ b/test/1.smoke.test.js
@@ -3,7 +3,7 @@
 
 const request = require('supertest')
 const bodyParser = require('body-parser')
-const expect = require('chai').expect
+const { expect } = require('chai')
 let gateway, service, close, proxy, gHttpServer
 
 describe('fast-proxy smoke', () => {
@@ -22,6 +22,8 @@ describe('fast-proxy smoke', () => {
     // init gateway
     gateway = require('restana')()
     gateway.use(bodyParser.json())
+    gateway.use(bodyParser.urlencoded({ extended: true }))
+    gateway.use(bodyParser.text())
 
     gateway.all('/service/*', function (req, res) {
       proxy(req, res, req.url, {})
@@ -46,9 +48,16 @@ describe('fast-proxy smoke', () => {
     // init remote service
     service = require('restana')()
     service.use(bodyParser.json())
-
+    service.use(bodyParser.urlencoded({ extended: true }))
+    service.use(bodyParser.text())
     service.get('/service/get', (req, res) => res.send('Hello World!'))
     service.post('/service/post', (req, res) => {
+      res.send(req.body)
+    })
+    service.post('/service/post/urlencoded', (req, res) => {
+      res.send(req.body)
+    })
+    service.post('/service/post/text', (req, res) => {
       res.send(req.body)
     })
     service.get('/service/headers', (req, res) => {
@@ -74,10 +83,31 @@ describe('fast-proxy smoke', () => {
       .expect(200)
   })
 
-  it('should 200 on POST to valid remote endpoint', async () => {
+  it('should 200 on POST plain/text to valid remote endpoint', async () => {
+    await request(gHttpServer)
+      .post('/service/post/text')
+      .set('content-type', 'text/plain')
+      .send('name is john')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal('name is john')
+      })
+  })
+
+  it('should 200 on POST application/json to valid remote endpoint', async () => {
     await request(gHttpServer)
       .post('/service/post')
       .send({ name: 'john' })
+      .expect(200)
+      .then((res) => {
+        expect(res.body.name).to.equal('john')
+      })
+  })
+
+  it('should 200 on POST application/x-www-form-urlencoded to valid remote endpoint', async () => {
+    await request(gHttpServer)
+      .post('/service/post/urlencoded')
+      .send('name=john')
       .expect(200)
       .then((res) => {
         expect(res.body.name).to.equal('john')

--- a/test/5.undici.test.js
+++ b/test/5.undici.test.js
@@ -3,7 +3,7 @@
 
 const request = require('supertest')
 const bodyParser = require('body-parser')
-const expect = require('chai').expect
+const { expect } = require('chai')
 let gateway, service, close, proxy, gHttpServer
 
 describe('undici', () => {
@@ -24,7 +24,7 @@ describe('undici', () => {
   it('init & start gateway', async () => {
     // init gateway
     gateway = require('restana')()
-
+    gateway.use(bodyParser.json())
     gateway.all('/service/*', function (req, res) {
       proxy(req, res, req.url, {})
     })
@@ -58,14 +58,15 @@ describe('undici', () => {
   it('should 200 on POST to valid remote endpoint', async () => {
     await request(gHttpServer)
       .post('/service/post')
-      .send({ name: 'john' })
+      .set('Content-Type', 'application/json')
+      .send('{"name":"john"}')
       .expect(200)
       .then((res) => {
         expect(res.body.name).to.equal('john')
       })
   })
 
-  it('should 200 on GET /servive/headers', async () => {
+  it('should 200 on GET /service/headers', async () => {
     await request(gHttpServer)
       .get('/service/headers')
       .expect(200)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

1. Add support to application/x-www-form-urlencoded content-type
2. Fix failed test in undici.test.js file
3. Added test to test content-type: text/plain and application/x-www-form-urlencoded
#### Checklist

- [V ] run `npm run test` and `npm run benchmark`
- [ V] tests and/or benchmarks are included
- [ NA] documentation is changed or added
- [ ]V commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
