### PR TITLE
adding :authority header support for http2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "10"
-  - "12"
   - "14"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "10"
+  - "12"
   - "14"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "10"
   - "14"
 
 before_install:

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = (opts) => {
             if (err.code === 'ECONNREFUSED' || err.code === 'ERR_HTTP2_STREAM_CANCEL') {
               res.statusCode = 503
               res.end('Service Unavailable')
-            } else if (err.code === 'ECONNRESET' || err.code === 'UND_ERR_REQUEST_TIMEOUT') {
+            } else if (err.code === 'ECONNRESET' || err.code === 'UND_ERR_HEADERS_TIMEOUT' || err.code === 'UND_ERR_BODY_TIMEOUT') {
               res.statusCode = 504
               res.end(err.message)
             } else {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ module.exports = (opts) => {
       const url = getReqUrl(source || req.url, cache, base, opts)
       const sourceHttp2 = req.httpVersionMajor === 2
       let headers = { ...sourceHttp2 ? filterPseudoHeaders(req.headers) : req.headers }
-      headers['x-forwarded-host'] = req.headers.host
+
+      headers['x-forwarded-host'] = headers.host
       headers.host = url.hostname
       if (url.port) {
         headers.host += `:${url.port}`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,11 @@ function filterPseudoHeaders (headers) {
   const dest = {}
   const headersKeys = Object.keys(headers)
 
+  if (headers[':authority']) {
+    // see: https://nodejs.org/api/http2.html#http2_note_on_authority_and_host
+    dest.host = headers[':authority']
+  }
+
   let header
   let i
   for (i = 0; i < headersKeys.length; i++) {
@@ -12,6 +17,7 @@ function filterPseudoHeaders (headers) {
       dest[header.toLowerCase()] = headers[header]
     }
   }
+
   return dest
 }
 

--- a/package.json
+++ b/package.json
@@ -34,27 +34,25 @@
   },
   "homepage": "https://github.com/fastify/fast-proxy",
   "devDependencies": {
-    "0http": "^2.5.2",
+    "0http": "^3.0.0",
     "body-parser": "^1.19.0",
-    "chai": "^4.2.0",
-    "fastify": "^3.0.3",
-    "fastify-reply-from": "^3.1.2",
-    "follow-redirects": "^1.13.0",
+    "chai": "^4.3.0",
+    "follow-redirects": "^1.13.3",
     "h2url": "^0.2.0",
     "http-proxy": "^1.18.1",
-    "mocha": "^8.0.1",
-    "nock": "^13.0.2",
+    "mocha": "^8.3.0",
+    "nock": "^13.0.9",
     "nyc": "^15.1.0",
     "pem": "^1.14.4",
-    "restana": "^4.6.2",
-    "standard": "^14.3.4",
-    "supertest": "^4.0.2"
+    "restana": "^4.8.1",
+    "standard": "^16.0.3",
+    "supertest": "^6.1.3"
   },
   "dependencies": {
     "end-of-stream": "^1.4.4",
     "pump": "^3.0.0",
-    "semver": "^7.3.2",
+    "semver": "^7.3.4",
     "tiny-lru": "^7.0.6",
-    "undici": "^1.2.2"
+    "undici": "^3.3.3"
   }
 }

--- a/test/3.http2.test.js
+++ b/test/3.http2.test.js
@@ -87,6 +87,8 @@ describe('http2', () => {
 
       service.get('/service/headers', (req, res) => {
         res.setHeader('x-agent', 'fast-proxy')
+        res.setHeader('x-forwarded-host', req.headers['x-forwarded-host'])
+
         res.send()
       })
 
@@ -96,10 +98,14 @@ describe('http2', () => {
 
   it('should 200 on GET headers', async () => {
     const { headers } = await h2url.concat({
-      url: 'https://localhost:8080/service/headers'
+      url: 'https://localhost:8080/service/headers',
+      headers: {
+        ':authority': 'nodejs.org:443'
+      }
     })
     expect(headers[':status']).to.equal(200)
     expect(headers['x-agent']).to.equal('fast-proxy')
+    expect(headers['x-forwarded-host']).to.equal('nodejs.org:443')
   })
 
   it('should timeout on GET /service/longop', async () => {

--- a/test/5.undici.test.js
+++ b/test/5.undici.test.js
@@ -15,7 +15,7 @@ describe('undici', () => {
       base: 'http://127.0.0.1:3000',
       undici: {
         pipelining: 10,
-        requestTimeout: 100
+        headersTimeout: 100
       }
     })
     close = fastProxy.close
@@ -57,7 +57,7 @@ describe('undici', () => {
     })
     service.get('/service/timeout', async (req, res) => {
       await sleep(200)
-      res.send()
+      res.send('OK')
     })
 
     service.start(3000).then(() => done())


### PR DESCRIPTION
Changes: 
- Adding support for `:authority` header in HTTP2 (https://nodejs.org/api/http2.html#http2_note_on_authority_and_host)
- Fixes issue that caused `undefined` `x-forwarded-host` header value (https://github.com/fastify/fast-proxy/pull/7#discussion_r578032873)

cc @marcbachmann