### PR TITLE
Overwriting requests agent and other properties with opts.request object

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,90 +1,89 @@
-"use strict";
+'use strict'
 
-const semver = require("semver");
-const http = require("http");
-const https = require("https");
-const eos = require("end-of-stream");
-const pump = require("pump");
-const { stripHttp1ConnectionHeaders } = require("./utils");
-const undici = require("undici");
+const semver = require('semver')
+const http = require('http')
+const https = require('https')
+const eos = require('end-of-stream')
+const pump = require('pump')
+const { stripHttp1ConnectionHeaders } = require('./utils')
+const undici = require('undici')
 
-function buildRequest(opts) {
-  const isHttp2 = !!opts.http2;
-  const isUndici = !!opts.undici;
+function buildRequest (opts) {
+  const isHttp2 = !!opts.http2
+  const isUndici = !!opts.undici
   const requests = {
-    "http:": opts.requests && opts.requests.http ? opts.requests.http : http,
-    "https:":
-      opts.requests && opts.requests.https ? opts.requests.https : https,
-  };
-  const baseUrl = opts.base;
-  const rejectUnauthorized = opts.rejectUnauthorized;
-  let h2client;
-  let agents;
-  let http2;
-  let pool;
+    'http:': opts.requests && opts.requests.http ? opts.requests.http : http,
+    'https:':
+      opts.requests && opts.requests.https ? opts.requests.https : https
+  }
+  const baseUrl = opts.base
+  const rejectUnauthorized = opts.rejectUnauthorized
+  let h2client
+  let agents
+  let http2
+  let pool
 
   if (isHttp2) {
-    if (semver.lt(process.version, "9.0.0")) {
-      throw new Error("Http2 support requires Node version >= 9.0.0");
+    if (semver.lt(process.version, '9.0.0')) {
+      throw new Error('Http2 support requires Node version >= 9.0.0')
     }
-    if (!opts.base)
-      throw new Error("Option base is required when http2 is true");
+    if (!opts.base) { throw new Error('Option base is required when http2 is true') }
   } else {
     agents = {
-      "http:": new http.Agent(agentOption(opts)),
-      "https:": new https.Agent(agentOption(opts)),
-    };
+      'http:': new http.Agent(agentOption(opts)),
+      'https:': new https.Agent(agentOption(opts))
+    }
   }
 
   if (isHttp2) {
-    http2 = getHttp2();
-    return { request: handleHttp2Req, close };
+    http2 = getHttp2()
+    return { request: handleHttp2Req, close }
   } else if (isUndici) {
-    if (typeof opts.undici !== "object") {
-      opts.undici = {};
+    if (typeof opts.undici !== 'object') {
+      opts.undici = {}
     }
-    pool = new undici.Pool(baseUrl, opts.undici);
+    pool = new undici.Pool(baseUrl, opts.undici)
 
-    return { request: handleUndici, close };
+    return { request: handleUndici, close }
   } else {
-    return { request: handleHttp1Req, close };
+    return { request: handleHttp1Req, close }
   }
 
-  function close() {
+  function close () {
     if (isUndici) {
-      pool.destroy();
+      pool.destroy()
     } else if (!isHttp2) {
-      agents["http:"].destroy();
-      agents["https:"].destroy();
+      agents['http:'].destroy()
+      agents['https:'].destroy()
     } else if (h2client) {
-      h2client.destroy();
+      h2client.destroy()
     }
   }
 
-  function handleUndici(opts, done) {
+  function handleUndici (opts, done) {
     const req = {
       path: opts.url.pathname + opts.qs,
       method: opts.method,
       headers: opts.headers,
-      body: opts.body,
-    };
+      body: opts.body
+    }
 
     pool.request(req, function (err, res) {
       if (err) {
-        done(err);
+        done(err)
       } else {
         setImmediate(() =>
           done(null, {
             statusCode: res.statusCode,
             headers: res.headers,
-            stream: res.body,
+            stream: res.body
           })
-        );
+        )
       }
-    });
+    })
   }
 
-  function handleHttp1Req(opts, done) {
+  function handleHttp1Req (opts, done) {
     const req = requests[opts.url.protocol].request({
       method: opts.method,
       port: opts.url.port,
@@ -92,90 +91,90 @@ function buildRequest(opts) {
       hostname: opts.url.hostname,
       headers: opts.headers,
       agent: agents[opts.url.protocol],
-      ...opts.request,
-    });
-    req.on("error", done);
-    req.on("timeout", () => req.abort());
-    req.on("response", (res) => {
+      ...opts.request
+    })
+    req.on('error', done)
+    req.on('timeout', () => req.abort())
+    req.on('response', (res) => {
       setImmediate(() =>
         done(null, {
           statusCode: res.statusCode,
           headers: res.headers,
-          stream: res,
+          stream: res
         })
-      );
-    });
-    end(req, opts.body, done);
+      )
+    })
+    end(req, opts.body, done)
   }
 
-  function handleHttp2Req(opts, done) {
+  function handleHttp2Req (opts, done) {
     if (!h2client || h2client.destroyed) {
-      h2client = http2.connect(baseUrl, { rejectUnauthorized });
-      h2client.once("error", done);
+      h2client = http2.connect(baseUrl, { rejectUnauthorized })
+      h2client.once('error', done)
       // we might enqueue a large number of requests in this connection
       // before it's connected
-      h2client.setMaxListeners(0);
-      h2client.on("connect", () => {
+      h2client.setMaxListeners(0)
+      h2client.on('connect', () => {
         // reset the max listener to 10 on connect
-        h2client.setMaxListeners(10);
-        h2client.removeListener("error", done);
-      });
+        h2client.setMaxListeners(10)
+        h2client.removeListener('error', done)
+      })
     }
 
     const req = h2client.request({
-      ":method": opts.method,
-      ":path": opts.url.pathname + opts.qs,
-      ...stripHttp1ConnectionHeaders(opts.headers),
-    });
+      ':method': opts.method,
+      ':path': opts.url.pathname + opts.qs,
+      ...stripHttp1ConnectionHeaders(opts.headers)
+    })
     if (opts.request && opts.request.timeout) {
-      req.setTimeout(opts.request.timeout);
+      req.setTimeout(opts.request.timeout)
     }
 
-    const isGet = opts.method === "GET" || opts.method === "get";
+    const isGet = opts.method === 'GET' || opts.method === 'get'
     if (!isGet) {
-      end(req, opts.body, done);
+      end(req, opts.body, done)
     }
     eos(req, (err) => {
-      if (err) done(err);
-    });
-    req.on("timeout", () => {
-      const err = new Error("socket hang up");
-      err.code = "ECONNRESET";
+      if (err) done(err)
+    })
+    req.on('timeout', () => {
+      const err = new Error('socket hang up')
+      err.code = 'ECONNRESET'
 
-      req.destroy(err);
-    });
-    req.on("response", (headers) => {
+      req.destroy(err)
+    })
+    req.on('response', (headers) => {
       setImmediate(() => {
-        const statusCode = headers[":status"];
-        done(null, { statusCode, headers, stream: req });
-      });
-    });
+        const statusCode = headers[':status']
+        done(null, { statusCode, headers, stream: req })
+      })
+    })
   }
 }
 
-module.exports = buildRequest;
+module.exports = buildRequest
 
-function agentOption(opts) {
+function agentOption (opts) {
   return {
     keepAlive: true,
     keepAliveMsecs: 60 * 1000, // 1 minute
     maxSockets: 2048,
     maxFreeSockets: 2048,
-    ...opts,
-  };
+    ...opts
+  }
 }
 
-function end(req, body, cb) {
-  if (!body || typeof body === "string") {
-    req.end(body);
+function end (req, body, cb) {
+  if (!body || typeof body === 'string') {
+    req.end(body)
   } else {
     pump(body, req, (err) => {
-      if (err) cb(err);
-    });
+      if (err) cb(err)
+    })
   }
 }
 
 // neede to avoid the experimental warning
-function getHttp2() {
-  return require("http2");
+function getHttp2 () {
+  return require('http2')
 }


### PR DESCRIPTION
Thank you fo this amazing plugin.

This is a very minor change that will make this plugin more flexible.

I have override the request "agent:" property in `function handleHttp1Req (opts, done)` by prioritising `...opts.request`. object.

This is just making sure that whenever we pass custom properties to `opts.request` object e.g. opts.request.agent, it will be prioritised and overwrites existing property declarations.





<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
