### PR TITLE
Types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ service.start(3000)
 ```
 
 Using imports:
-```js
+```ts
 import fastProxy from 'fast-proxy'
 
 const { proxy, close } = fastProxy({

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ service.get('/service/hi', (req, res) => res.send('Hello World!'))
 service.start(3000)
 ```
 
+Using imports:
+```js
+import fastProxy from 'fast-proxy'
+
+const { proxy, close } = fastProxy({
+  base: 'http://127.0.0.1:3000'
+})
+```
+
 ## Benchmarks
 Please see: https://github.com/jkyberneees/nodejs-proxy-benchmarks
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,9 +25,9 @@ declare function fastProxy(options?: Options): {
     source: string,
     opts?: {
       base?: string;
-      onResponse?(req: _req, res: _res, stream: Stream): void;
-      rewriteRequestHeaders?(req: _req, headers: { [key as string]: string }): { headers: { [key as string]: string } };
-      rewriteHeaders?(headers: { [key as string]: string }): { headers: { [key as string]: string } };
+      onResponse?(req: Http.IncomingMessage, res: Http.ServerResponse, stream: Stream): void;
+      rewriteRequestHeaders?(req: Http.IncomingMessage, headers: Http.IncomingHttpHeaders): Http.IncomingHttpHeaders;
+      rewriteHeaders?(headers: Http.OutgoingHttpHeaders): Http.OutgoingHttpHeaders;
       request?: Http.RequestOptions;
       queryString?: string;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,38 @@
+import * as Http from 'http';
+import * as Https from 'https';
+import { Stream } from 'pump';
+import * as Undici from 'undici';
+
+interface Options {
+  base?: string;
+  http2?: boolean;
+  undici?: Undici.Pool.Options;
+  cacheURLs?: number;
+  requests?: {
+    http?: Http.Agent,
+    https?: Https.Agent
+  };
+  keepAliveMsecs?: number;
+  maxSockets?: number;
+  rejectUnauthorized?: boolean;
+}
+
+
+declare function fastProxy(options?: Options): {
+  proxy(
+    originReq: Http.IncomingMessage,
+    originRes: Http.ServerResponse,
+    source: string,
+    opts?: {
+      base?: string;
+      onResponse?(req: _req, res: _res, stream: Stream): void;
+      rewriteRequestHeaders?(req: _req, headers: { [key as string]: string }): { headers: { [key as string]: string } };
+      rewriteHeaders?(headers: { [key as string]: string }): { headers: { [key as string]: string } };
+      request?: Http.RequestOptions;
+      queryString?: string;
+    }
+  ): void;
+  close(): void;
+}
+
+export default fastProxy

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function populateHeaders (headers, body, contentType) {
   }
 }
 
-module.exports = (opts) => {
+module.exports = function fastProxy (opts = {}) {
   const { request, close } = buildRequest({
     ...opts
   })

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "files": [
     "LICENSE",
     "README.md",
+    "index.d.ts",
     "index.js",
     "lib/"
   ],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Forward your HTTP request to another server.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "npx standard",
     "test": "nyc mocha test/*.test.js",
@@ -53,6 +54,6 @@
     "pump": "^3.0.0",
     "semver": "^7.3.4",
     "tiny-lru": "^7.0.6",
-    "undici": "^3.3.3"
+    "undici": "^4.4.5"
   }
 }


### PR DESCRIPTION
Added in `index.d.ts` to help anyone looking to use "import" notation.
Added in `.editorconfig` to help maintain best practice formatting already in place
Updated documentation to demonstrate the import.
Updated the exported function to be named for debug traceability. 


I also updated Undici to the latest version since it's a bit behind.... but I noticed in the benchmarks that it's dropped a good amount in performance.  I'm happy to roll this part back if needed.


Benchmarks (Ryzen 9 5950x not overclocked, Windows 10 WSL2, Node 16.6.2)

```
http-proxy@1.18.1

$ wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi
Running 30s test @ http://127.0.0.1:8080/service/hi
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.39ms  278.93us  16.90ms   94.71%
    Req/Sec   716.52     59.82   818.00     95.38%
  171239 requests in 30.02s, 17.47MB read
Requests/sec:   5704.38
Transfer/sec:    596.06KB
```

```
fast-proxy@2.0.0

$ wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi
Running 30s test @ http://127.0.0.1:8080/service/hi
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   717.22us  172.06us  12.70ms   95.65%
    Req/Sec     1.41k   118.17     3.40k    94.71%
  336380 requests in 30.10s, 43.31MB read
Requests/sec:  11175.51
Transfer/sec:      1.44MB
```

```
fast-proxy@THIS_PR

$ wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi
Running 30s test @ http://127.0.0.1:8080/service/hi
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   724.16us  149.96us  11.03ms   95.57%
    Req/Sec     1.39k   117.25     3.34k    94.88%
  332852 requests in 30.10s, 42.85MB read
Requests/sec:  11058.33
Transfer/sec:      1.42MB
```

```
fast-proxy@2.0.0 w/ undici

$ wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi
Running 30s test @ http://127.0.0.1:8080/service/hi
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   470.60us  176.94us  11.99ms   94.88%
    Req/Sec     2.16k   198.11     2.28k    94.68%
  516665 requests in 30.10s, 66.52MB read
Requests/sec:  17164.61
Transfer/sec:      2.21MB
```

```
fast-proxy@THIS_PR w/ undici

$ wrk -t8 -c8 -d30s http://127.0.0.1:8080/service/hi
Running 30s test @ http://127.0.0.1:8080/service/hi
  8 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   542.14us  196.34us  12.60ms   89.01%
    Req/Sec     1.87k   169.67     2.46k    94.72%
  447481 requests in 30.10s, 57.61MB read
Requests/sec:  14866.22
Transfer/sec:      1.91MB
```









#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
