### PR TITLE
fix: adding Host header value validation on proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const lru = require('tiny-lru')
 const querystring = require('querystring')
 const Stream = require('stream')
 const buildRequest = require('./lib/request')
+
 const {
   filterPseudoHeaders,
   copyHeaders,
@@ -42,6 +43,15 @@ function fastProxy (opts = {}) {
       const url = getReqUrl(source || req.url, cache, base, opts)
       const sourceHttp2 = req.httpVersionMajor === 2
       let headers = { ...sourceHttp2 ? filterPseudoHeaders(req.headers) : req.headers }
+
+      if (!headers.host) {
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host
+        // @TODO: Should add performance-aware host header value validation(regex-based) as a further step?
+        res.statusCode = 400
+        res.end()
+
+        return
+      }
 
       headers['x-forwarded-host'] = headers.host
       headers.host = url.hostname

--- a/test/11.host-header-val.test.js
+++ b/test/11.host-header-val.test.js
@@ -1,0 +1,39 @@
+/* global describe, it */
+'use strict'
+
+const request = require('supertest')
+let gateway, close, proxy, gHttpServer
+
+describe('Host header validation', () => {
+  it('init', async () => {
+    const fastProxy = require('../index')({
+      base: 'http://127.0.0.1:3000'
+    })
+
+    proxy = fastProxy.proxy
+    close = fastProxy.close
+  })
+
+  it('init & start gateway', async () => {
+    // init gateway
+    gateway = require('restana')()
+
+    gateway.all('/service/*', function (req, res) {
+      delete req.headers.host
+      proxy(req, res, req.url, {})
+    })
+
+    gHttpServer = await gateway.start(8080)
+  })
+
+  it('should fail with Bad Request when Host header is missing', async () => {
+    await request(gHttpServer)
+      .get('/service/headers')
+      .expect(400)
+  })
+
+  it('close all', async () => {
+    close()
+    await gateway.close()
+  })
+})


### PR DESCRIPTION
This PR fixes/add first level of validation to the Host header value. Without this check, the proxy would throw an internal error if the Host header is missing. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
