### PR TITLE
Fix `requests` http agent parameter in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This flag could controls the settings of the undici client, like so:
 The number of parsed URLs that will be cached. Default: 100.
 > Use value = `0` to disable the caching mechanism
 
-#### requests.http and requests.https
+#### requests['http:'] and requests['https:']
 Allows to optionally overwrite the internal `http` and `https` client agents implementation. Defaults: [`http`](https://nodejs.org/api/http.html#http_http) and [`https`](https://nodejs.org/api/https.html#https_https).
 
 For example, this could be used to add support for following redirects, like so:
@@ -90,8 +90,8 @@ For example, this could be used to add support for following redirects, like so:
 ```js
 ...
   requests: {
-    http: require('follow-redirects/http'),
-    https: require('follow-redirects/https')
+    'http:': require('follow-redirects/http'),
+    'https:': require('follow-redirects/https')
   }
 ...
 ```


### PR DESCRIPTION
The parameters in the readme were wrong.
I got the error `requests[opts.url.protocol].request is not a function`.

```diff
  requests: {
-    http: require('follow-redirects/http'),
-    https: require('follow-redirects/https')
+    'http:': require('follow-redirects/http'),
+    'https:': require('follow-redirects/https')
  }
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
