### PR TITLE
Handle OPTIONS content-length

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const {
   filterPseudoHeaders,
   copyHeaders,
   stripHttp1ConnectionHeaders,
-  filterHeaders,
   buildURL
 } = require('./lib/utils')
 
@@ -53,11 +52,11 @@ function fastProxy (opts = {}) {
 
       let body = null
       // according to https://tools.ietf.org/html/rfc2616#section-4.3
-      // proxy should ignore message body when it's a GET or HEAD request
+      // proxy should ignore message body when it's a GET, HEAD or OPTIONS request
       // when proxy this request, we should reset the content-length to make it a valid http request
-      if (req.method === 'GET' || req.method === 'HEAD') {
-        if (headers['content-length']) {
-          headers = filterHeaders(headers, 'content-length')
+      if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
+        if (headers.hasOwnProperty('content-length')) {
+          delete headers['content-length']
         }
       } else {
         if (req.body) {

--- a/test/5.undici.test.js
+++ b/test/5.undici.test.js
@@ -55,6 +55,9 @@ describe('undici', () => {
       res.setHeader('x-agent', 'fast-proxy')
       res.send(req.headers)
     })
+    service.options('/service/headers', (req, res) => {
+      res.send(null, 204, {...req.headers})
+    })
     service.get('/service/timeout', async (req, res) => {
       await sleep(200)
       res.send('OK')
@@ -87,8 +90,18 @@ describe('undici', () => {
       .set('content-length', '10')
       .then((response) => {
         expect(response.headers['x-agent']).to.equal('fast-proxy')
-        expect(response.body['content-length']).to.equal(undefined) // content-length is stripped for GET / HEAD requests
+        expect(response.body['content-length']).to.equal(undefined) // content-length is stripped for GET, HEAD and OPTIONS requests
         expect(response.body.host).to.equal('127.0.0.1:3000')
+      })
+  })
+
+  it('should 204 on OPTIONS /service/headers', async () => {
+    await request(gHttpServer)
+      .options('/service/headers')
+      .expect(204)
+      .set('content-length', '0')
+      .then((response) => {
+        expect(response.headers['content-length']).to.equal(undefined) // content-length is stripped for GET, HEAD and OPTIONS requests
       })
   })
 


### PR DESCRIPTION
Fixes #82, with a new test reflecting that.

Note that the method to remove the `content-length` header is slightly changed:
- `hasOwnProperty` is probably better
- `delete` is more straightforward than using `filterHeaders()`.
By the way, that function was only used here but I leaved it in lib/util.js, in case you would like to keep it.