### PR TITLE
fix: check for flushed response headers during proxy request errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,8 @@ function fastProxy (opts = {}) {
       }
       request(reqParams, (err, response) => {
         if (err) {
+          // check if response has already been sent and all data has been flushed 
+          // before configuring error response headers
           if (!res.sent || !res.writableFinished) {
             if (err.code === 'ECONNREFUSED' || err.code === 'ERR_HTTP2_STREAM_CANCEL') {
               res.statusCode = 503

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function fastProxy (opts = {}) {
       }
       request(reqParams, (err, response) => {
         if (err) {
-          if (!res.sent) {
+          if (!res.sent || !res.writableFinished) {
             if (err.code === 'ECONNREFUSED' || err.code === 'ERR_HTTP2_STREAM_CANCEL') {
               res.statusCode = 503
               res.end('Service Unavailable')

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function fastProxy (opts = {}) {
       }
       request(reqParams, (err, response) => {
         if (err) {
-          // check if response has already been sent and all data has been flushed 
+          // check if response has already been sent and all data has been flushed
           // before configuring error response headers
           if (res.sent === false || res.writableFinished === false) {
             if (err.code === 'ECONNREFUSED' || err.code === 'ERR_HTTP2_STREAM_CANCEL') {

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function fastProxy (opts = {}) {
         if (err) {
           // check if response has already been sent and all data has been flushed 
           // before configuring error response headers
-          if (!res.sent || !res.writableFinished) {
+          if (res.sent === false || res.writableFinished === false) {
             if (err.code === 'ECONNREFUSED' || err.code === 'ERR_HTTP2_STREAM_CANCEL') {
               res.statusCode = 503
               res.end('Service Unavailable')

--- a/test/1.smoke.test.js
+++ b/test/1.smoke.test.js
@@ -25,9 +25,15 @@ describe('fast-proxy smoke', () => {
     gateway.use(bodyParser.urlencoded({ extended: true }))
     gateway.use(bodyParser.text())
 
+    gateway.get('/service/flushed', function(req, res) {
+      res.end();
+      proxy(req, res, req.url, {})
+    })
+
     gateway.all('/service/*', function (req, res) {
       proxy(req, res, req.url, {})
     })
+
 
     gHttpServer = await gateway.start(8080)
   })
@@ -42,6 +48,12 @@ describe('fast-proxy smoke', () => {
     await request(gHttpServer)
       .get('/service/get')
       .expect(503)
+  })
+
+  it('should 200 when proxy errors after response has been sent', async () => {
+    await request(gHttpServer)
+      .get('/service/flushed')
+      .expect(200);
   })
 
   it('init & start remote service', async () => {

--- a/test/1.smoke.test.js
+++ b/test/1.smoke.test.js
@@ -34,7 +34,6 @@ describe('fast-proxy smoke', () => {
       proxy(req, res, req.url, {})
     })
 
-
     gHttpServer = await gateway.start(8080)
   })
 

--- a/test/1.smoke.test.js
+++ b/test/1.smoke.test.js
@@ -25,8 +25,8 @@ describe('fast-proxy smoke', () => {
     gateway.use(bodyParser.urlencoded({ extended: true }))
     gateway.use(bodyParser.text())
 
-    gateway.get('/service/flushed', function(req, res) {
-      res.end();
+    gateway.get('/service/flushed', function (req, res) {
+      res.end()
       proxy(req, res, req.url, {})
     })
 
@@ -52,7 +52,7 @@ describe('fast-proxy smoke', () => {
   it('should 200 when proxy errors after response has been sent', async () => {
     await request(gHttpServer)
       .get('/service/flushed')
-      .expect(200);
+      .expect(200)
   })
 
   it('init & start remote service', async () => {


### PR DESCRIPTION
Resolves #86 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
