### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Set to `true` if target server is `http2` enabled.
 
 #### undici
 Set to `true` to use [undici](https://github.com/mcollina/undici)
-instead of `require('http')`. Enabling this flag should guarantee
+instead of `require('node:http')`. Enabling this flag should guarantee
 20-50% more throughput.
 
 This flag could controls the settings of the undici client, like so:

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const pump = require('pump')
 const lru = require('tiny-lru').lru
-const Stream = require('stream')
+const Stream = require('node:stream')
 const buildRequest = require('./lib/request')
 const {
   filterPseudoHeaders,

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const semver = require('semver')
-const http = require('http')
-const https = require('https')
+const http = require('node:http')
+const https = require('node:https')
 const eos = require('end-of-stream')
 const pump = require('pump')
 const { stripHttp1ConnectionHeaders } = require('./utils')
@@ -163,5 +163,5 @@ function end (req, body, cb) {
 
 // neede to avoid the experimental warning
 function getHttp2 () {
-  return require('http2')
+  return require('node:http2')
 }

--- a/test/2.https.test.js
+++ b/test/2.https.test.js
@@ -43,7 +43,7 @@ describe('https', () => {
   it('init & start remote service', (done) => {
     // init remote service
     service = require('restana')({
-      server: require('https').createServer({
+      server: require('node:https').createServer({
         key,
         cert
       })

--- a/test/3.http2.test.js
+++ b/test/3.http2.test.js
@@ -43,7 +43,7 @@ describe('http2', () => {
     // init gateway
 
     gateway = require('restana')({
-      server: require('http2').createSecureServer({
+      server: require('node:http2').createSecureServer({
         key,
         cert
       })
@@ -65,7 +65,7 @@ describe('http2', () => {
   it('init & start remote service', (done) => {
     // init remote service
     service = require('restana')({
-      server: require('http2').createSecureServer({
+      server: require('node:http2').createSecureServer({
         key,
         cert
       })

--- a/test/4.opts.test.js
+++ b/test/4.opts.test.js
@@ -5,7 +5,7 @@ const request = require('supertest')
 const bodyParser = require('body-parser')
 const expect = require('chai').expect
 const pump = require('pump')
-const queryString = require('querystring')
+const queryString = require('node:querystring')
 let gateway, service, close, proxy, gHttpServer
 
 const nock = require('nock')

--- a/test/5.undici.test.js
+++ b/test/5.undici.test.js
@@ -2,7 +2,7 @@
 'use strict'
 const request = require('supertest')
 const bodyParser = require('body-parser')
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const { expect } = require('chai')
 
 const sleep = promisify(setTimeout)


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
